### PR TITLE
Fix reverse mapping error in recommendation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,11 +182,15 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+
+# Frontend build and dependency directories
+frontend/node_modules/
+frontend/package-lock.json
 
 # Ruff stuff:
 .ruff_cache/

--- a/backend/app.py
+++ b/backend/app.py
@@ -90,9 +90,11 @@ class RecommendationSystem:
         
         # Create user and movie mappings
         self.user_to_idx = {user.id: idx for idx, user in enumerate(users)}
-        self.idx_to_user = {idx: user.id for user_id, idx in self.user_to_idx.items()}
+        # Reverse mapping from index to user ID
+        self.idx_to_user = {idx: user_id for user_id, idx in self.user_to_idx.items()}
         self.movie_to_idx = {movie.id: idx for idx, movie in enumerate(movies)}
-        self.idx_to_movie = {idx: movie.id for movie_id, idx in self.movie_to_idx.items()}
+        # Reverse mapping from index to movie ID
+        self.idx_to_movie = {idx: movie_id for movie_id, idx in self.movie_to_idx.items()}
         
         # Prepare content features for content-based filtering
         movie_features = []


### PR DESCRIPTION
## Summary
- Correct index-to-ID mapping for users and movies in backend recommendation system
- Ignore frontend dependency directories in version control

## Testing
- `python -m py_compile backend/app.py`
- `cd frontend && npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899369c0bb4832d84d648c8fa3726f2